### PR TITLE
Support several release series

### DIFF
--- a/circle/docker-pull-cache.sh
+++ b/circle/docker-pull-cache.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -e
+
+# Copyright 2017 Bitnami
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKERFILE=${DOCKERFILE:-Dockerfile}
+
+log() {
+  echo -e "$(date "+%T.%2N") ${@}"
+}
+
+info() {
+  log "INFO  ==> ${@}"
+}
+
+warn() {
+  log "WARN  ==> ${@}"
+}
+
+error() {
+  log "ERROR ==> ${@}"
+}
+
+if [[ -n $RELEASE_SERIES_LIST ]]; then
+  IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "$RELEASE_SERIES_LIST"
+  for RS in "${RELEASE_SERIES_ARRAY[@]}"; do
+    docker pull $DOCKER_PROJECT/$IMAGE_NAME:$RS-buildcache || true
+  done
+else
+  docker pull $DOCKER_PROJECT/$IMAGE_NAME:_ || true
+fi


### PR DESCRIPTION
This diff allows to have different release series per diff. This should work with the current state of the repositories but if they define something like:
bitnami-docker-php-fpm/circle.yaml:
```
machine:
  environment:
    - RELEASE_SERIES_LIST="5.6,7.0,7.1"
    - LATEST_STABLE="7.1"
```

It will automatically maintain a tag per release series marking one as "latest"