### PR TITLE
Revert "circle: upgrade `libcurl` package"

### DIFF
--- a/circle/docker-development-image.sh
+++ b/circle/docker-development-image.sh
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# WORKAROUND: https://github.com/docker-library/docker/issues/72
-apk upgrade --no-cache libcurl
-
 CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 

--- a/circle/docker-image-test.sh
+++ b/circle/docker-image-test.sh
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# WORKAROUND: https://github.com/docker-library/docker/issues/72
-apk upgrade --no-cache libcurl
-
 CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 

--- a/circle/docker-pull-cache.sh
+++ b/circle/docker-pull-cache.sh
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# WORKAROUND: https://github.com/docker-library/docker/issues/72
-apk upgrade --no-cache libcurl
-
 CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 

--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# WORKAROUND: https://github.com/docker-library/docker/issues/72
-apk upgrade --no-cache libcurl
-
 CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 


### PR DESCRIPTION
This reverts commit 5de2e808bb9d41f7a5155b125fcfcb0288b9124e.

Since `curl` is used in the `circle.yml` steps, the `libcurl` upgrade
should be performed in the `circle.yml` build steps