### PR TITLE
DO NOT MERGE - POC of CircleCI scrips to build debian and centos images

### DIFF
--- a/circle/docker-development-image.sh
+++ b/circle/docker-development-image.sh
@@ -32,7 +32,7 @@ if [[ -n $DOCKER_PASS ]]; then
         IMAGE_BUILD_CACHE=`get_image_build_cache $DOCKER_PROJECT $IMAGE_NAME $RS $BI`
         IMAGE_BUILD_TAG=`get_image_build_tag $CIRCLE_BRANCH $BI`
         IMAGE_BUILD_DIR=`get_image_build_dir $RS $BI`
-        docker_build_and_push $DOCKER_PROJECT/$IMAGE_NAME:$IMAGE_BUILD_TAG $IMAGE_BUILD_DIR $IMAGE_BUILD_CACHE || exit 1
+        docker_build_and_push $DOCKER_PROJECT/$IMAGE_NAME:$RS-$IMAGE_BUILD_TAG $IMAGE_BUILD_DIR $IMAGE_BUILD_CACHE || exit 1
       done
     done
   else

--- a/circle/docker-development-image.sh
+++ b/circle/docker-development-image.sh
@@ -17,15 +17,30 @@
 CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 
+# SUPPORTED_BASE_IMAGES will be an array of comma separated base images. Default to debian if not declared
+if [[ -z $SUPPORTED_BASE_IMAGES ]]; then
+    SUPPORTED_BASE_IMAGES=debian
+fi
+IFS=',' read -ra SUPPORTED_BASE_IMAGES_ARRAY <<< "$SUPPORTED_BASE_IMAGES"
+
 if [[ -n $DOCKER_PASS ]]; then
   docker_login || exit 1
   if [[ -n $RELEASE_SERIES_LIST ]]; then
     IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "$RELEASE_SERIES_LIST"
     for RS in "${RELEASE_SERIES_ARRAY[@]}"; do
-      docker_build_and_push $DOCKER_PROJECT/$IMAGE_NAME:$RS-$CIRCLE_BRANCH $RS $DOCKER_PROJECT/$IMAGE_NAME:$RS || exit 1
+      for BI in "${SUPPORTED_BASE_IMAGES_ARRAY[@]}"; do
+        IMAGE_BUILD_CACHE=`get_image_build_cache $DOCKER_PROJECT $IMAGE_NAME $RS $BI`
+        IMAGE_BUILD_TAG=`get_image_build_tag $CIRCLE_BRANCH $BI`
+        IMAGE_BUILD_DIR=`get_image_build_dir $RS $BI`
+        docker_build_and_push $DOCKER_PROJECT/$IMAGE_NAME:$IMAGE_BUILD_TAG $IMAGE_BUILD_DIR $IMAGE_BUILD_CACHE || exit 1
+      done
     done
   else
-    docker_build_and_push $DOCKER_PROJECT/$IMAGE_NAME:$CIRCLE_BRANCH . $DOCKER_PROJECT/$IMAGE_NAME:latest || exit 1
+    for BI in "${SUPPORTED_BASE_IMAGES_ARRAY[@]}"; do
+      IMAGE_BUILD_CACHE=`get_image_build_cache $DOCKER_PROJECT $IMAGE_NAME latest $BI`
+      IMAGE_BUILD_TAG=`get_image_build_tag $CIRCLE_BRANCH $BI`
+      docker_build_and_push $DOCKER_PROJECT/$IMAGE_NAME:$IMAGE_BUILD_TAG . $IMAGE_BUILD_CACHE || exit 1
+    done
   fi
   dockerhub_update_description || exit 1
 fi

--- a/circle/docker-image-test.sh
+++ b/circle/docker-image-test.sh
@@ -28,8 +28,6 @@ docker_load_cache
 if [[ -n $RELEASE_SERIES_LIST ]]; then
   IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "$RELEASE_SERIES_LIST"
   for RS in "${RELEASE_SERIES_ARRAY[@]}"; do
-
-    IFS=',' read -ra SUPPORTED_BASE_IMAGES_ARRAY <<< "$SUPPORTED_BASE_IMAGES"
     if [[ -n $IMAGE_TAG ]]; then
       if [[ "$IMAGE_TAG" == "$RS"* ]]; then
         for BI in "${SUPPORTED_BASE_IMAGES_ARRAY[@]}"; do

--- a/circle/docker-image-test.sh
+++ b/circle/docker-image-test.sh
@@ -24,19 +24,20 @@ docker_load_cache
 if [[ -n $RELEASE_SERIES_LIST ]]; then
   IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "$RELEASE_SERIES_LIST"
   for RS in "${RELEASE_SERIES_ARRAY[@]}"; do
+
     IFS=',' read -ra SUPPORTED_BASE_IMAGES_ARRAY <<< "$SUPPORTED_BASE_IMAGES"
     if [[ -n $IMAGE_TAG ]]; then
-        if [[ "$IMAGE_TAG" == "$RS"* ]]; then
-            for BI in "${SUPPORTED_BASE_IMAGES_ARRAY[@]}"; do
-                [[ $BI != "debian" ]] && TAG=$RS-$BI || TAG=$RS
-                docker_build $DOCKER_PROJECT/$IMAGE_NAME:$TAG $RS/$BI || exit 1
-            done
-        fi
-    else
+      if [[ "$IMAGE_TAG" == "$RS"* ]]; then
         for BI in "${SUPPORTED_BASE_IMAGES_ARRAY[@]}"; do
-            [[ $BI != "debian" ]] && TAG=$RS-$BI || TAG=$RS
-            docker_build $DOCKER_PROJECT/$IMAGE_NAME:$TAG $RS/$BI || exit 1
+          [[ $BI != "debian" ]] && TAG=$RS-$BI || TAG=$RS
+          docker_build $DOCKER_PROJECT/$IMAGE_NAME:$TAG $RS/$BI || exit 1
         done
+      fi
+    else
+      for BI in "${SUPPORTED_BASE_IMAGES_ARRAY[@]}"; do
+        [[ $BI != "debian" ]] && TAG=$RS-$BI || TAG=$RS
+        docker_build $DOCKER_PROJECT/$IMAGE_NAME:$TAG $RS/$BI || exit 1
+      done
     fi
   done
 else

--- a/circle/docker-image-test.sh
+++ b/circle/docker-image-test.sh
@@ -14,22 +14,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+echo "======> Forked and edited script <======"
+
 CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
-
-echo "========== Forked script =========="
 
 docker_load_cache
 
 if [[ -n $RELEASE_SERIES_LIST ]]; then
   IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "$RELEASE_SERIES_LIST"
   for RS in "${RELEASE_SERIES_ARRAY[@]}"; do
+    IFS=',' read -ra SUPPORTED_BASE_IMAGES_ARRAY <<< "$SUPPORTED_BASE_IMAGES"
     if [[ -n $IMAGE_TAG ]]; then
-      if [[ "$IMAGE_TAG" == "$RS"* ]]; then
-        docker_build $DOCKER_PROJECT/$IMAGE_NAME:$RS $RS || exit 1
-      fi
+        if [[ "$IMAGE_TAG" == "$RS"* ]]; then
+            for BI in "${SUPPORTED_BASE_IMAGES_ARRAY[@]}"; do
+                [[ $BI != "debian" ]] && TAG=$RS-$BI || TAG=$RS
+                docker_build $DOCKER_PROJECT/$IMAGE_NAME:$TAG $RS/$BI || exit 1
+            done
+        fi
     else
-      docker_build $DOCKER_PROJECT/$IMAGE_NAME:$RS $RS || exit 1
+        for BI in "${SUPPORTED_BASE_IMAGES_ARRAY[@]}"; do
+            [[ $BI != "debian" ]] && TAG=$RS-$BI || TAG=$RS
+            docker_build $DOCKER_PROJECT/$IMAGE_NAME:$TAG $RS/$BI || exit 1
+        done
     fi
   done
 else

--- a/circle/docker-image-test.sh
+++ b/circle/docker-image-test.sh
@@ -17,6 +17,8 @@
 CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 
+echo "========== Forked script =========="
+
 docker_load_cache
 
 if [[ -n $RELEASE_SERIES_LIST ]]; then

--- a/circle/docker-image-test.sh
+++ b/circle/docker-image-test.sh
@@ -16,7 +16,7 @@
 
 echo "======> Forked and edited script <======"
 
-CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
+CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/tompizmor/test-infra/centos-poc/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 
 docker_load_cache

--- a/circle/docker-pull-cache.sh
+++ b/circle/docker-pull-cache.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 echo "========== Forked script =========="
 
-CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
+CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/tompizmor/test-infra/centos-poc/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 
 if [[ -n $RELEASE_SERIES_LIST ]]; then

--- a/circle/docker-pull-cache.sh
+++ b/circle/docker-pull-cache.sh
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+echo "========== Forked script =========="
 
 CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)

--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+echo "========== Forked script =========="
+
 CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 

--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -16,7 +16,7 @@
 
 echo "========== Forked script =========="
 
-CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
+CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/tompizmor/test-infra/centos-poc/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 
 # RELEASE_SERIES_LIST will be an array of comma separated release series

--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo "========== Forked script =========="
+echo "========== Forked and edited script =========="
 
 CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/tompizmor/test-infra/centos-poc/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
@@ -26,6 +26,12 @@ if [[ -n $RELEASE_SERIES_LIST && -z $LATEST_STABLE ]]; then
   exit 1
 fi
 IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "$RELEASE_SERIES_LIST"
+
+# SUPPORTED_BASE_IMAGES will be an array of comma separated base images. Default to debian if not declared
+if [[ -z $SUPPORTED_BASE_IMAGES ]]; then
+  SUPPORTED_BASE_IMAGES=debian
+fi
+IFS=',' read -ra SUPPORTED_BASE_IMAGES_ARRAY <<< "$SUPPORTED_BASE_IMAGES"
 
 MATCHING_RS_FOUND=0
 for RS in "${RELEASE_SERIES_ARRAY[@]}"; do
@@ -54,30 +60,43 @@ fi
 
 if [[ -n $DOCKER_PROJECT && -n $DOCKER_PASS ]]; then
   docker_login || exit 1
+
   for TAG in "${TAGS_TO_UPDATE[@]}"; do
-    docker_build_and_push $DOCKER_PROJECT/$IMAGE_NAME:$TAG $RELEASE_SERIES $DOCKER_PROJECT/$IMAGE_NAME:$RELEASE_SERIES || exit 1
+    for BI in "${SUPPORTED_BASE_IMAGES_ARRAY[@]}"; do
+      [[ $BI != "debian" ]] && BUILD_TAG=$TAG-$BI || BUILD_TAG=$TAG
+      [[ $BI != "debian" ]] && IMAGE_BUILD_CACHE=$DOCKER_PROJECT/$IMAGE_NAME:$RELEASE_SERIES-$BI || IMAGE_BUILD_CACHE=$DOCKER_PROJECT/$IMAGE_NAME:$RELEASE_SERIES
+      if [[ -f $RELEASE_SERIES/Dockerfile ]]; then
+        IMAGE_BUILD_DIR=$RELEASE_SERIES
+      elif [[ -f $RELEASE_SERIES/$BI/Dockerfile ]]; then
+        IMAGE_BUILD_DIR=$RELEASE_SERIES/$BI
+      else
+        error "Dockerfile not found. Check the Dockerfile is present either in the release_series folder or the base_image folder"
+	exit 1
+      fi
+      docker_build_and_push $DOCKER_PROJECT/$IMAGE_NAME:$BUILD_TAG $IMAGE_BUILD_DIR $IMAGE_BUILD_CACHE || exit 1
 
-    # workaround: publish dreamfactory docker image to dreamfactorysoftware/df-docker as well
-    if [[ $IMAGE_NAME == dreamfactory ]]; then
-      docker_build_and_push dreamfactorysoftware/df-docker:$TAG $RELEASE_SERIES $DOCKER_PROJECT/$IMAGE_NAME:$RELEASE_SERIES || exit 1
-      if [[ -f README.md ]]; then
-        if ! curl -sSf "https://hub.docker.com/v2/users/login/" \
-          -H "Content-Type: application/json" \
-          --data '{"username": "'${DOCKER_USER}'", "password": "'${DOCKER_PASS}'"}' -o /tmp/token.json; then
-          return 1
-        fi
-        DOCKER_TOKEN=$(grep token /tmp/token.json | cut -d':' -f2 | cut -d'"' -f2)
+      # workaround: publish dreamfactory docker image to dreamfactorysoftware/df-docker as well
+      if [[ $IMAGE_NAME == dreamfactory ]]; then
+        docker_build_and_push dreamfactorysoftware/df-docker:$TAG $IMAGE_BUILD_DIR $IMAGE_BUILD_CACHE || exit 1
+        if [[ -f README.md ]]; then
+          if ! curl -sSf "https://hub.docker.com/v2/users/login/" \
+            -H "Content-Type: application/json" \
+            --data '{"username": "'${DOCKER_USER}'", "password": "'${DOCKER_PASS}'"}' -o /tmp/token.json; then
+              return 1
+          fi
+          DOCKER_TOKEN=$(grep token /tmp/token.json | cut -d':' -f2 | cut -d'"' -f2)
 
-        info "Updating image description on Docker Hub..."
-        echo "{\"full_description\": \"$(sed 's/bitnami\/dreamfactory:latest/dreamfactorysoftware\/df-docker:latest/g' README.md | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')\"}" > /tmp/description.json
-        if ! curl -sSf "https://hub.docker.com/v2/repositories/dreamfactorysoftware/df-docker/" -o /dev/null \
-          -H "Content-Type: application/json" \
-          -H "Authorization: JWT ${DOCKER_TOKEN}" \
-          -X PATCH --data @/tmp/description.json; then
-          return 1
+          info "Updating image description on Docker Hub..."
+          echo "{\"full_description\": \"$(sed 's/bitnami\/dreamfactory:latest/dreamfactorysoftware\/df-docker:latest/g' README.md | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')\"}" > /tmp/description.json
+          if ! curl -sSf "https://hub.docker.com/v2/repositories/dreamfactorysoftware/df-docker/" -o /dev/null \
+            -H "Content-Type: application/json" \
+            -H "Authorization: JWT ${DOCKER_TOKEN}" \
+            -X PATCH --data @/tmp/description.json; then
+            return 1
+          fi
         fi
       fi
-    fi
+    done
   done
 fi
 

--- a/circle/functions
+++ b/circle/functions
@@ -427,3 +427,38 @@ chart_update_version() {
     git commit -m "$CHART_NAME: bump chart version to \`$CHART_VERSION_NEXT\`" >/dev/null
   fi
 }
+
+get_image_build_dir() {
+    local RELEASE_SERIE=${1}
+    local BASE_IMAGE=${2}
+
+    if [[ -f $RS/Dockerfile ]]; then
+        IMAGE_BUILD_DIR=$RELEASE_SERIE
+    elif [[ -f $RS/$BI/Dockerfile ]]; then
+        IMAGE_BUILD_DIR=$RELEASE_SERIE/$BASE_IMAGE
+    else
+        error "Dockerfile not found. Check the Dockerfile is present either in the release_series folder or the base_image folder"
+	exit 1
+    fi
+    echo $IMAGE_BUILD_DIR
+}
+
+get_image_build_tag() {
+    local BASE_TAG=${1}
+    local BASE_IMAGE=${2}
+
+    [[ $BI != "debian" ]] && IMAGE_BUILD_TAG=$BASE_TAG-$BASE_IMAGE || IMAGE_BUILD_TAG=$BASE_TAG
+
+    echo $IMAGE_BUILD_TAG
+}
+
+get_image_build_cache() {
+    local DOCKER_PROJECT=${1}
+    local IMAGE_NAME=${2}
+    local BASE_TAG=${3}
+    local BASE_IMAGE=${4}
+
+    [[ $BI != "debian" ]] && IMAGE_BUILD_CACHE=$DOCKER_PROJECT/$IMAGE_NAME:$RS-$BI || IMAGE_BUILD_CACHE=$DOCKER_PROJECT/$IMAGE_NAME:$RS
+
+    echo $IMAGE_BUILD_CACHE
+}


### PR DESCRIPTION
This PR adds support to the circle ci scripts to build and tag docker images based on different operating systems. By default, it will only build `debian` unless the env var SUPPORTED_BASE_IMAGES is defined.

At this moment our repo structure is:

```
1.12/
├── docker-compose.yml
├── Dockerfile
└── rootfs
    ├── app-entrypoint.sh
    └── nginx-inputs.json
```

Once we add centos and debian images we will move to this other one:

```
1.12/
├── centos
│   ├── docker-compose.yml
│   ├── Dockerfile
│   └── rootfs
│       ├── app-entrypoint.sh
│       └── nginx-inputs.json
└── debian
    ├── docker-compose.yml
    ├── Dockerfile
    └── rootfs
        ├── app-entrypoint.sh
        └── nginx-inputs.json
```

The scripts try to find first a Dockerfile according to the first structure and they fallback to the second one if they can't find it.