### PR TITLE
feature: allow users to customize test and release pipelines

### DIFF
--- a/circle/docker-image-test.sh
+++ b/circle/docker-image-test.sh
@@ -19,6 +19,15 @@ source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 
 docker_load_cache
 
+# Execute custom pre-tests scripts
+if [[ -d .circleci/scripts/pre-tests.d/ ]]; then
+  for script in $(find .circleci/scripts/pre-tests.d/*.sh | sort -n)
+  do
+    info "Triggering $script..."
+    source $script
+  done
+fi
+
 if [[ -n $RELEASE_SERIES_LIST ]]; then
   IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "$RELEASE_SERIES_LIST"
   for RS in "${RELEASE_SERIES_ARRAY[@]}"; do
@@ -32,6 +41,15 @@ if [[ -n $RELEASE_SERIES_LIST ]]; then
   done
 else
   docker_build $DOCKER_PROJECT/$IMAGE_NAME . || exit 1
+fi
+
+# Execute custom post-tests scripts
+if [[ -d .circleci/scripts/post-tests.d/ ]]; then
+  for script in $(find .circleci/scripts/post-tests.d/*.sh | sort -n)
+  do
+    info "Triggering $script..."
+    source $script
+  done
 fi
 
 docker_save_cache $DOCKER_PROJECT/$IMAGE_NAME

--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -50,6 +50,15 @@ else
   TAGS_TO_UPDATE+=('latest')
 fi
 
+# Execute custom pre-release scripts
+if [[ -d .circleci/scripts/pre-release.d/ ]]; then
+  for script in $(find .circleci/scripts/pre-release.d/*.sh | sort -n)
+  do
+    info "Triggering $script..."
+    source $script
+  done
+fi
+
 if [[ -n $DOCKER_PROJECT && -n $DOCKER_PASS ]]; then
   docker_login || exit 1
   for TAG in "${TAGS_TO_UPDATE[@]}"; do
@@ -181,4 +190,13 @@ if [[ -n $CHART_REPO && -n $CHART_NAME && -n $DOCKER_PROJECT && -n $DOCKER_PASS 
       warn "Chart release/updates skipped!"
     fi
   fi
+fi
+
+# Execute custom post-release scripts
+if [[ -d .circleci/scripts/post-release.d/ ]]; then
+  for script in $(find .circleci/scripts/post-release.d/*.sh | sort -n)
+  do
+    info "Triggering $script..."
+    source $script
+  done
 fi


### PR DESCRIPTION
This commit allows users to add custom scripts that will be execute pre
and post tests and releases as configured.

Custom scripts should be present in the repo at the following locations.

 - .circleci/scripts/pre-tests.d/
 - .circleci/scripts/post-tests.d/
 - .circleci/scripts/pre-release.d/
 - .circleci/scripts/post-release.d/