### PR TITLE
Add support to build Dockerfile from php/ folder

### DIFF
--- a/circle/functions
+++ b/circle/functions
@@ -18,7 +18,7 @@ DOCKER_SERVER_VERSION=$(docker version --format '{{.Server.Version}}')
 DOCKER_CLIENT_VERSION=$(docker version --format '{{.Client.Version}}')
 
 DOCKERFILE=${DOCKERFILE:-Dockerfile}
-SUPPORTED_VARIANTS="dev prod onbuild buildpack"
+SUPPORTED_VARIANTS="dev prod onbuild buildpack php"
 
 DOCKER_PROJECT=${DOCKER_PROJECT:-}
 QUAY_PROJECT=${QUAY_PROJECT:-}


### PR DESCRIPTION
Since https://github.com/bitnami/minideb-runtimes/pull/1 we should build the Dockerfile located at the php/ folder.
It is a dockerfile for building the base image for the php production container.