### PR TITLE
Allow updating several helm charts repos

### DIFF
--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -107,17 +107,18 @@ if [[ -n $CHART_REPO && -n $CHART_NAME && -n $DOCKER_PROJECT && -n $DOCKER_PASS 
   # perform chart updates only for the specified LATEST_STABLE release
   if [[ -n $LATEST_STABLE && "$IMAGE_TAG" == "$LATEST_STABLE"* ]] || [[ -z $LATEST_STABLE ]]; then
     # Update main chart repository
-    info "Going to update main chart repo"
+    info "Going to update main chart repository"
     update_chart_in_repo $CHART_REPO
-    info "Main chart repo updated"
+    info "Updated $CHART_NAME in main repository"
 
     # Also update extra chart repository if exists
     if [[ -n $EXTRA_CHART_REPOS_LIST ]]; then
       IFS=',' read -ra CHART_REPOS_TO_UPDATE_ARRAY <<< "$EXTRA_CHART_REPOS_LIST"
       for chart_repository in ${CHART_REPOS_TO_UPDATE_ARRAY[@]}
       do
-        info "Going to update $CHART_NAME in $chart_repository repo"
+        info "Going to update $CHART_NAME in $chart_repository repository"
         update_chart_in_repo $chart_repository
+	info "Updated $CHART_NAME in $chart_repository repository"
       done
     fi
 

--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
+CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/tompizmor/test-infra/chart-test/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 
 # RELEASE_SERIES_LIST will be an array of comma separated release series

--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -106,83 +106,18 @@ fi
 if [[ -n $CHART_REPO && -n $CHART_NAME && -n $DOCKER_PROJECT && -n $DOCKER_PASS ]]; then
   # perform chart updates only for the specified LATEST_STABLE release
   if [[ -n $LATEST_STABLE && "$IMAGE_TAG" == "$LATEST_STABLE"* ]] || [[ -z $LATEST_STABLE ]]; then
-    info "Cloning '$CHART_REPO' repo..."
-    if ! git clone --quiet --single-branch $CHART_REPO charts; then
-      error "Could not clone $CHART_REPO..."
-      exit 1
-    fi
-    cd charts
+    # Update main chart repository
+    update_chart_in_repo $CHART_REPO
 
-    # add development remote
-    git remote add development https://$GITHUB_USER@github.com/$GITHUB_USER/$(echo ${CHART_REPO/https:\/\/github.com\/} | tr / -).git
-
-    # lookup chart in the chart repo
-    CHART_PATH=
-    for d in $(find * -type d -name $CHART_NAME )
-    do
-      if [ -f $d/Chart.yaml ]; then
-        CHART_PATH=$d
-        break
-      fi
-    done
-
-    if [[ -z $CHART_PATH ]]; then
-      error "Chart '$CHART_NAME' could not be found in '$CHART_REPO' repo"
-      exit 1
-    fi
-
-    if [[ -z $GITHUB_USER || -z $GITHUB_PASSWORD ]]; then
-      error "GitHub credentials not configured. Aborting..."
-      exit 1
-    fi
-
-    git_configure
-
-    # generate next chart version
-    CHART_VERSION=$(grep '^version:' $CHART_PATH/Chart.yaml | awk '{print $2}')
-    CHART_VERSION_NEXT="${CHART_VERSION%.*}.$((${CHART_VERSION##*.}+1))"
-
-    # create a branch for the updates
-    git_create_branch $CHART_NAME $CHART_VERSION_NEXT
-
-    if chart_update_image $CHART_PATH $CHART_IMAGE; then
-      chart_update_requirements $CHART_PATH
-      chart_update_appVersion $CHART_PATH $CHART_IMAGE
-      chart_update_version $CHART_PATH $CHART_VERSION_NEXT
-
-      info "Publishing branch to remote repo..."
-      git push development $CHART_NAME-$CHART_VERSION_NEXT >/dev/null
-
-      if [[ $SKIP_CHART_PULL_REQUEST -eq 0 && -z $BRANCH_AMEND_COMMITS ]]; then
-        install_hub || exit 1
-
-        info "Creating pull request with '$CHART_REPO' repo..."
-        if ! hub pull-request -m "[$CHART_PATH] Release $CHART_VERSION_NEXT"; then
-          error "Could not create pull request"
-          exit 1
-        fi
-
-        # auto merge updates to https://github.com/bitnami/charts
-        if [[ $CHART_REPO == "https://github.com/bitnami/charts" ]]; then
-          info "Auto-merging $CHART_NAME-$CHART_VERSION_NEXT..."
-          git checkout master >/dev/null
-          git merge --no-ff $CHART_NAME-$CHART_VERSION_NEXT >/dev/null
-          git remote remove origin >/dev/null
-          git remote add origin https://$GITHUB_USER@$(echo ${CHART_REPO/https:\/\/}).git >/dev/null
-          git push origin master >/dev/null
-        fi
-      fi
-
-      info "Cleaning up old branches..."
-      git fetch development >/dev/null
-      for branch in $(git branch --remote --list development/$CHART_NAME-* | sed 's?.*development/??' | grep -v "^$CHART_NAME-$CHART_VERSION_NEXT$")
+    # Also update extra chart repository if exists
+    if [[ -n $EXTRA_CHART_REPOS_LIST ]]; then
+      IFS=',' read -ra CHART_REPOS_TO_UPDATE_ARRAY <<< "$EXTRA_CHART_REPOS_LIST"
+      for chart_repository in ${CHART_REPOS_TO_UPDATE_ARRAY[@]}
       do
-        log "Deleting $branch..."
-        git push development :$branch >/dev/null
+        update_chart_in_repo $chart_repository
       done
-    else
-      warn "Chart release/updates skipped!"
     fi
+
   fi
 fi
 

--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -107,13 +107,16 @@ if [[ -n $CHART_REPO && -n $CHART_NAME && -n $DOCKER_PROJECT && -n $DOCKER_PASS 
   # perform chart updates only for the specified LATEST_STABLE release
   if [[ -n $LATEST_STABLE && "$IMAGE_TAG" == "$LATEST_STABLE"* ]] || [[ -z $LATEST_STABLE ]]; then
     # Update main chart repository
+    info "Going to update main chart repo"
     update_chart_in_repo $CHART_REPO
+    info "Main chart repo updated"
 
     # Also update extra chart repository if exists
     if [[ -n $EXTRA_CHART_REPOS_LIST ]]; then
       IFS=',' read -ra CHART_REPOS_TO_UPDATE_ARRAY <<< "$EXTRA_CHART_REPOS_LIST"
       for chart_repository in ${CHART_REPOS_TO_UPDATE_ARRAY[@]}
       do
+        info "Going to update $CHART_NAME in $chart_repository repo"
         update_chart_in_repo $chart_repository
       done
     fi

--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/tompizmor/test-infra/chart-test/circle/functions}
+CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 
 # RELEASE_SERIES_LIST will be an array of comma separated release series

--- a/circle/functions
+++ b/circle/functions
@@ -379,9 +379,16 @@ dockerhub_update_description() {
 }
 
 chart_update_image() {
+
+  info "XXXXXX: sss{1} is ${1}"
+
   local CHART_NEW_IMAGE_VERSION=${2#*:}
+  info "XXXXXX: CHART_NEW_IMAGE_VERSION is $CHART_NEW_IMAGE_VERSION"
   local CHART_CURRENT_IMAGE_VERSION=$(grep "^[ ]*image:[ ]*${2%:*}" ${1}/values.yaml)
+  info "XXXXXX 1: CHART_CURRENT_IMAGE_VERSION is $CHART_CURRENT_IMAGE_VERSION"
   local CHART_CURRENT_IMAGE_VERSION=${CHART_CURRENT_IMAGE_VERSION##*:}
+  info "XXXXXX 2: CHART_CURRENT_IMAGE_VERSION is $CHART_CURRENT_IMAGE_VERSION"
+
   case $(vercmp $CHART_CURRENT_IMAGE_VERSION $CHART_NEW_IMAGE_VERSION) in
     "0" )
       warn "Chart image \`${2}\` has not been updated."

--- a/circle/functions
+++ b/circle/functions
@@ -463,3 +463,90 @@ chart_package() {
   helm package --destination $dest $src >/dev/null || return 1
   helm repo index $dest ${CHART_URL:+--url $CHART_URL/${chart%%/*}}
 }
+
+update_chart_in_repo() {
+  local REPO_TO_UPDATE=${1}
+
+  info "Cloning '$REPO_TO_UPDATE' repo..."
+  if ! git clone --quiet --single-branch $REPO_TO_UPDATE charts; then
+    error "Could not clone $REPO_TO_UPDATE..."
+    exit 1
+  fi
+  cd charts
+
+  # add development remote
+  git remote add development https://$GITHUB_USER@github.com/$GITHUB_USER/$(echo ${REPO_TO_UPDATE/https:\/\/github.com\/} | tr / -).git
+
+  # lookup chart in the chart repo
+  CHART_PATH=
+  for d in $(find * -type d -name $CHART_NAME )
+  do
+    if [ -f $d/Chart.yaml ]; then
+      CHART_PATH=$d
+      break
+    fi
+  done
+
+  if [[ -z $CHART_PATH ]]; then
+    error "Chart '$CHART_NAME' could not be found in '$REPO_TO_UPDATE' repo"
+    exit 1
+  fi
+
+  if [[ -z $GITHUB_USER || -z $GITHUB_PASSWORD ]]; then
+    error "GitHub credentials not configured. Aborting..."
+    exit 1
+  fi
+
+  git_configure
+
+  # generate next chart version
+  CHART_VERSION=$(grep '^version:' $CHART_PATH/Chart.yaml | awk '{print $2}')
+  CHART_VERSION_NEXT="${CHART_VERSION%.*}.$((${CHART_VERSION##*.}+1))"
+
+  # create a branch for the updates
+  git_create_branch $CHART_NAME $CHART_VERSION_NEXT
+
+  if chart_update_image $CHART_PATH $CHART_IMAGE; then
+    chart_update_requirements $CHART_PATH
+    chart_update_appVersion $CHART_PATH $CHART_IMAGE
+    chart_update_version $CHART_PATH $CHART_VERSION_NEXT
+
+    info "Publishing branch to remote repo..."
+    git push development $CHART_NAME-$CHART_VERSION_NEXT >/dev/null
+
+    if [[ $SKIP_CHART_PULL_REQUEST -eq 0 && -z $BRANCH_AMEND_COMMITS ]]; then
+      install_hub || exit 1
+
+      info "Creating pull request with '$REPO_TO_UPDATE' repo..."
+      if ! hub pull-request -m "[$CHART_PATH] Release $CHART_VERSION_NEXT"; then
+        error "Could not create pull request"
+        exit 1
+      fi
+
+      # auto merge updates to https://github.com/bitnami/charts
+      if [[ $REPO_TO_UPDATE == "https://github.com/bitnami/charts" ]]; then
+        info "Auto-merging $CHART_NAME-$CHART_VERSION_NEXT..."
+        git checkout master >/dev/null
+        git merge --no-ff $CHART_NAME-$CHART_VERSION_NEXT >/dev/null
+        git remote remove origin >/dev/null
+        git remote add origin https://$GITHUB_USER@$(echo ${REPO_TO_UPDATE/https:\/\/}).git >/dev/null
+        git push origin master >/dev/null
+      fi
+    fi
+
+    info "Cleaning up old branches..."
+    git fetch development >/dev/null
+    for branch in $(git branch --remote --list development/$CHART_NAME-* | sed 's?.*development/??' | grep -v "^$CHART_NAME-$CHART_VERSION_NEXT$")
+    do
+      log "Deleting $branch..."
+      git push development :$branch >/dev/null
+    done
+
+    info "Cleaning up repository"
+    # Exiting from charts/ repository
+    cd ..
+    rm -rf charts
+  else
+    warn "Chart release/updates skipped!"
+  fi
+}

--- a/circle/functions
+++ b/circle/functions
@@ -513,6 +513,8 @@ update_chart_in_repo() {
   # create a branch for the updates
   git_create_branch $CHART_NAME $CHART_VERSION_NEXT
 
+
+  info "XX: CHART_PATH is $CHART_PATH and CHART_IMAGE is $CHART_IMAGE"
   if chart_update_image $CHART_PATH $CHART_IMAGE; then
     chart_update_requirements $CHART_PATH
     chart_update_appVersion $CHART_PATH $CHART_IMAGE

--- a/circle/functions
+++ b/circle/functions
@@ -379,15 +379,9 @@ dockerhub_update_description() {
 }
 
 chart_update_image() {
-
-  info "XXXXXX: sss{1} is ${1}"
-
   local CHART_NEW_IMAGE_VERSION=${2#*:}
-  info "XXXXXX: CHART_NEW_IMAGE_VERSION is $CHART_NEW_IMAGE_VERSION"
   local CHART_CURRENT_IMAGE_VERSION=$(grep "^[ ]*image:[ ]*${2%:*}" ${1}/values.yaml)
-  info "XXXXXX 1: CHART_CURRENT_IMAGE_VERSION is $CHART_CURRENT_IMAGE_VERSION"
   local CHART_CURRENT_IMAGE_VERSION=${CHART_CURRENT_IMAGE_VERSION##*:}
-  info "XXXXXX 2: CHART_CURRENT_IMAGE_VERSION is $CHART_CURRENT_IMAGE_VERSION"
 
   case $(vercmp $CHART_CURRENT_IMAGE_VERSION $CHART_NEW_IMAGE_VERSION) in
     "0" )
@@ -513,8 +507,6 @@ update_chart_in_repo() {
   # create a branch for the updates
   git_create_branch $CHART_NAME $CHART_VERSION_NEXT
 
-
-  info "XX: CHART_PATH is $CHART_PATH and CHART_IMAGE is $CHART_IMAGE"
   if chart_update_image $CHART_PATH $CHART_IMAGE; then
     chart_update_requirements $CHART_PATH
     chart_update_appVersion $CHART_PATH $CHART_IMAGE


### PR DESCRIPTION
This PR adds support to update several chart repositories based on the `CHART_REPO` and `EXTRA_CHART_REPOS_LIST` env vars.

Ghost circle.yml example:

```
          CHART_REPO: https://github.com/bitnami/charts
          EXTRA_CHART_REPOS_LIST: "https://github.com/kubernetes/charts"
```

The EXTRA_CHART_REPOS_LIST is a comma-separated list of repositories.

We need this feature as we want bitnami/charts to be the source of truth of all Bitnami charts but we still want to update the charts in the kubernetes/charts repository.