### PR TITLE
Always update chart version

### DIFF
--- a/circle/functions
+++ b/circle/functions
@@ -439,12 +439,10 @@ chart_update_requirements() {
 }
 
 chart_update_version() {
-  if [[ -z $BRANCH_AMEND_COMMITS ]]; then
-    info "Updating chart version to '$2'..."
-    sed -i 's|^version:.*|version: '"${2}"'|g' ${1}/Chart.yaml
-    git add ${1}/Chart.yaml
-    git commit -m "$CHART_NAME: bump chart version to \`$CHART_VERSION_NEXT\`" >/dev/null
-  fi
+  info "Updating chart version to '$2'..."
+  sed -i 's|^version:.*|version: '"${2}"'|g' ${1}/Chart.yaml
+  git add ${1}/Chart.yaml
+  git commit -m "$CHART_NAME: bump chart version to \`$CHART_VERSION_NEXT\`" >/dev/null
 }
 
 chart_package() {


### PR DESCRIPTION
Now we are updating bitnami/charts and kubernetes/charts at the same time. Charts in bitnami/charts repo are automatically merged while charts in kubernetes need to be manually reviewed and merged.

Previously for kubernetes/charts, if we release a new version of the chart during the review process, we only updated the docker image but not the chart version. Now, in order to keep bitnami/charts and kubernetes/charts in sync, we should always update the chart version too.