### PR TITLE
Enable automerge PRs for minideb derived base images

### DIFF
--- a/circle/functions
+++ b/circle/functions
@@ -790,15 +790,14 @@ update_minideb_derived() {
     fi
 
     # auto merge updates
-    # only enable when we are certain automatic PRs are correct
-    # info "Auto-merging ${BRANCH_NAME}..."
-    # git_automerge_branch $REPO_TO_UPDATE $BRANCH_NAME
+    info "Auto-merging ${BRANCH_NAME} in ${REPO_TO_UPDATE}..."
+    git_automerge_branch $REPO_TO_UPDATE $BRANCH_NAME
 
     # create a new release
-    # if ! hub release create -m "Update minideb base image" $NEW_IMAGE_VERSION ; then
-    #     error "Could not create a release"
-    #     exit 1
-    # fi
+    if ! hub release create -m "Update minideb base image" $NEW_IMAGE_VERSION ; then
+        error "Could not create a release"
+	exit 1
+    fi
 
     info "Cleaning up old branches..."
     git_cleanup_old_branches $REPO_TO_UPDATE "${BRANCH_NAME_BASE}-*" "^${BRANCH_NAME}$"


### PR DESCRIPTION
Continuing with the work started at https://github.com/bitnami/test-infra/pull/68 to automatically release minideb derived base images using the latest minideb, the only pending thing was auto-merge the PRs and cut the release.

We didn't enable this part of the feature because we wanted to check that the PRs were valid before merging them.

**Current open PRs**

Minideb-extras (jessie): https://github.com/bitnami/minideb-extras/pull/142
Minideb-extras (stretch): https://github.com/bitnami/minideb-extras/pull/144
Minideb-runtimes (jessie): https://github.com/bitnami/minideb-runtimes/pull/5