### PR TITLE
Use GitHub branches for the chart repository

### DIFF
--- a/circle/functions
+++ b/circle/functions
@@ -559,14 +559,24 @@ chart_update_version() {
 
 chart_package() {
   local chart=${1}
+  local branch=${CIRCLE_BRANCH}
   local name=${chart##*/}
-  local subpath=${chart%%/*}
   local src=${CIRCLE_WORKING_DIRECTORY}/${chart}
-  local dest=${CHART_OUTPUT_DIR}/${subpath}
+  if [[ ${branch} == "master" ]]; then
+    branch="bitnami"
+  fi
+  local dest=${CHART_OUTPUT_DIR}/${branch}
   local repo_index=${dest}/index.yaml
 
-  mkdir -p $dest
+  info "XXXX: chart is ${chart}"
+  info "XXXX: name is ${name}"
+  info "XXXX: src is ${src}"
+  info "XXXX: dest is ${dest}"
+  info "XXXX: repo_index is ${repo_index}"
+  info "XXXX: s3 url to push chart would be: s3://$AWS_BUCKET/${branch}/index.yaml"
 
+  mkdir -p $dest
+ 
   # download the repo index.yaml file if it does not exist
   MERGE_INDEX=
   if [[ -f $repo_index ]]; then
@@ -576,7 +586,7 @@ chart_package() {
     install_s3cmd || exit 1
 
     # the download will fail for new repos
-    if s3cmd get s3://$AWS_BUCKET/${subpath}/index.yaml $repo_index; then
+    if s3cmd get s3://$AWS_BUCKET/${branch}/index.yaml $repo_index; then
       MERGE_INDEX=1
     fi
   fi
@@ -588,7 +598,7 @@ chart_package() {
 
   info "Packaging $src at $dest..."
   helm package --destination $dest $src >/dev/null || return 1
-  helm repo index $dest ${CHART_URL:+--url $CHART_URL/${subpath}} ${MERGE_INDEX:+--merge $repo_index}
+  helm repo index $dest ${CHART_URL:+--url $CHART_URL/${branch}} ${MERGE_INDEX:+--merge $repo_index}
 }
 
 update_chart_in_repo() {

--- a/circle/functions
+++ b/circle/functions
@@ -569,7 +569,6 @@ chart_package() {
   local repo_index=${dest}/index.yaml
 
   mkdir -p $dest
- 
   # download the repo index.yaml file if it does not exist
   MERGE_INDEX=
   if [[ -f $repo_index ]]; then

--- a/circle/functions
+++ b/circle/functions
@@ -27,6 +27,10 @@ QUAY_PROJECT=${QUAY_PROJECT:-}
 GCLOUD_PROJECT=${GCLOUD_PROJECT:-}
 
 CHART_OUTPUT_DIR=${CHART_OUTPUT_DIR:-/charts}
+CHART_BRANCH=${CIRCLE_BRANCH}
+if [[ ${CHART_BRANCH} == "master" ]]; then
+  CHART_BRANCH="bitnami"
+fi
 
 GIT_AUTHOR_NAME=${GIT_AUTHOR_NAME:-Bitnami Containers}
 GIT_AUTHOR_EMAIL=${GIT_AUTHOR_EMAIL:-containers@bitnami.com}
@@ -559,21 +563,10 @@ chart_update_version() {
 
 chart_package() {
   local chart=${1}
-  local branch=${CIRCLE_BRANCH}
   local name=${chart##*/}
   local src=${CIRCLE_WORKING_DIRECTORY}/${chart}
-  if [[ ${branch} == "master" ]]; then
-    branch="bitnami"
-  fi
-  local dest=${CHART_OUTPUT_DIR}/${branch}
+  local dest=${CHART_OUTPUT_DIR}/${CHART_BRANCH}
   local repo_index=${dest}/index.yaml
-
-  info "XXXX: chart is ${chart}"
-  info "XXXX: name is ${name}"
-  info "XXXX: src is ${src}"
-  info "XXXX: dest is ${dest}"
-  info "XXXX: repo_index is ${repo_index}"
-  info "XXXX: s3 url to push chart would be: s3://$AWS_BUCKET/${branch}/index.yaml"
 
   mkdir -p $dest
  
@@ -586,7 +579,7 @@ chart_package() {
     install_s3cmd || exit 1
 
     # the download will fail for new repos
-    if s3cmd get s3://$AWS_BUCKET/${branch}/index.yaml $repo_index; then
+    if s3cmd get s3://$AWS_BUCKET/${CHART_BRANCH}/index.yaml $repo_index; then
       MERGE_INDEX=1
     fi
   fi
@@ -598,7 +591,7 @@ chart_package() {
 
   info "Packaging $src at $dest..."
   helm package --destination $dest $src >/dev/null || return 1
-  helm repo index $dest ${CHART_URL:+--url $CHART_URL/${branch}} ${MERGE_INDEX:+--merge $repo_index}
+  helm repo index $dest ${CHART_URL:+--url $CHART_URL/${CHART_BRANCH}} ${MERGE_INDEX:+--merge $repo_index}
 }
 
 update_chart_in_repo() {

--- a/circle/helm-package-charts.sh
+++ b/circle/helm-package-charts.sh
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/tompizmor/test-infra/chart_repo_branches/circle/functions}
+CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 
 install_helm || exit 1

--- a/circle/helm-package-charts.sh
+++ b/circle/helm-package-charts.sh
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
+CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/tompizmor/test-infra/chart_repo_branches/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 
 install_helm || exit 1

--- a/circle/helm-package-charts.sh
+++ b/circle/helm-package-charts.sh
@@ -18,10 +18,8 @@ source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 
 install_helm || exit 1
 
-# Adding bitnami chart repos to resolve dependencies while packaging the chart
-add_repo_to_helm bitnami-stable https://charts.bitnami.com/stable
-add_repo_to_helm bitnami-incubator https://charts.bitnami.com/incubator
-add_repo_to_helm bitnami-library https://charts.bitnami.com/library
+# Adding bitnami chart repo to resolve dependencies while packaging the chart
+add_repo_to_helm bitnami https://charts.bitnami.com/bitnami
 
 for chart_yaml in $(find $CIRCLE_WORKING_DIRECTORY -name Chart.yaml)
 do

--- a/circle/helm-publish-charts.sh
+++ b/circle/helm-publish-charts.sh
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/tompizmor/test-infra/chart_repo_branches/circle/functions}
+CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 
 if [[ -n $AWS_BUCKET && -n $AWS_ACCESS_KEY_ID && -n $AWS_SECRET_ACCESS_KEY ]]; then

--- a/circle/helm-publish-charts.sh
+++ b/circle/helm-publish-charts.sh
@@ -18,7 +18,7 @@ source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 
 if [[ -n $AWS_BUCKET && -n $AWS_ACCESS_KEY_ID && -n $AWS_SECRET_ACCESS_KEY ]]; then
   install_s3cmd || exit 1
-  s3cmd sync $CHART_OUTPUT_DIR/ s3://$AWS_BUCKET
+  s3cmd sync $CHART_OUTPUT_DIR/ s3://$AWS_BUCKET/
 else
   warn "S3 bucket not configured, cannot publish charts repo. Aborting!"
 fi

--- a/circle/helm-publish-charts.sh
+++ b/circle/helm-publish-charts.sh
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
+CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/tompizmor/test-infra/chart_repo_branches/circle/functions}
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 
 if [[ -n $AWS_BUCKET && -n $AWS_ACCESS_KEY_ID && -n $AWS_SECRET_ACCESS_KEY ]]; then


### PR DESCRIPTION
With this change we will stop mapping each folder in the master branch to a chart repo to start mapping **some** GitHub branches to chart repos. 
The branches that will be converted into a chart repo will in the [circleci configuration](https://github.com/bitnami/charts/blob/master/.circleci/config.yml#L26-L31) of the https://github.com/bitnami/charts repo.
