### PR TITLE
Enable back multi-distro support fixing minideb-extras case

### DIFF
--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -25,13 +25,30 @@ if [[ -n $RELEASE_SERIES_LIST && -z $LATEST_STABLE ]]; then
 fi
 IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "$RELEASE_SERIES_LIST"
 
+IS_DEFAULT_PLATFORM=1
+OS_PLATFORM=""
+if ! is_default_platform "$IMAGE_TAG" ; then
+  IS_DEFAULT_PLATFORM=0
+  OS_PLATFORM="$(get_os_platform "${IMAGE_TAG}")"
+  if [[ "${OS_PLATFORM}" = "rhel-"* ]]; then
+    info "Skipped publishing ${OS_PLATFORM} image: RHEL releases are disabled."
+    exit 0
+  fi
+fi
+
 MATCHING_RS_FOUND=0
 for RS in "${RELEASE_SERIES_ARRAY[@]}"; do
   if [[ "$IMAGE_TAG" == "$RS"* ]]; then
-    CACHE_TAG=$RS
-    RELEASE_SERIES=$RS
     let MATCHING_RS_FOUND+=1
-    TAGS_TO_UPDATE+=($RELEASE_SERIES)
+    RELEASE_SERIES="${RS}"
+    CACHE_TAG="${RELEASE_SERIES}"
+
+    if [ "${IS_DEFAULT_PLATFORM}" == 0 ] ; then
+        RELEASE_SERIES+="/${OS_PLATFORM}"
+        CACHE_TAG+="-${OS_PLATFORM}"
+    fi
+
+    TAGS_TO_UPDATE+=($CACHE_TAG)
   fi
 done
 
@@ -44,14 +61,16 @@ fi
 TAGS_TO_UPDATE+=($IMAGE_TAG)
 
 # Adding rolling tag
-TAGS_TO_UPDATE+=($ROLLING_IMAGE_TAG)
+TAGS_TO_UPDATE+=(${ROLLING_IMAGE_TAG})
 
-if [[ -n $RELEASE_SERIES ]]; then
-  if [[ $RELEASE_SERIES == $LATEST_STABLE ]]; then
+if [ "${IS_DEFAULT_PLATFORM}" == 1 ]; then
+  if [[ -n $RELEASE_SERIES ]]; then
+    if [[ $RELEASE_SERIES == $LATEST_STABLE ]]; then
+      [[ $LATEST_TAG_SOURCE == "LATEST_STABLE" ]] && TAGS_TO_UPDATE+=('latest')
+    fi
+  else
     [[ $LATEST_TAG_SOURCE == "LATEST_STABLE" ]] && TAGS_TO_UPDATE+=('latest')
   fi
-else
-  [[ $LATEST_TAG_SOURCE == "LATEST_STABLE" ]] && TAGS_TO_UPDATE+=('latest')
 fi
 
 # Execute custom pre-release scripts
@@ -106,7 +125,7 @@ if [[ -n $GCLOUD_PROJECT && -n $GCLOUD_SERVICE_KEY ]]; then
   done
 fi
 
-if [[ -n $AZURE_PROJECT && -n $AZURE_PORTAL_PASS && -n $AZURE_PORTAL_USER ]]; then
+if [[ "${IS_DEFAULT_PLATFORM}" == "1" && -n $AZURE_PROJECT && -n $AZURE_PORTAL_PASS && -n $AZURE_PORTAL_USER ]]; then
   az_login || exit 1
   for TAG in "${TAGS_TO_UPDATE[@]}"; do
     docker_build_and_push $AZURE_PORTAL_REGISTRY.azurecr.io/$AZURE_PROJECT/$IMAGE_NAME:$TAG $RELEASE_SERIES ${CACHE_TAG:+$DOCKER_PROJECT/$IMAGE_NAME:$CACHE_TAG} || exit 1

--- a/circle/functions
+++ b/circle/functions
@@ -41,7 +41,7 @@ export GITHUB_TOKEN
 
 IMAGE_NAME=${IMAGE_NAME:-}
 IMAGE_TAG=${CIRCLE_TAG:-}
-ROLLING_IMAGE_TAG=${IMAGE_TAG%-*}
+ROLLING_IMAGE_TAG=$(echo "${IMAGE_TAG}" | sed -E 's/^(.*?)-r[0-9]+(-.*?)?$/\1\2/')
 CHART_IMAGE_REPOSITORY=${CHART_IMAGE_REPOSITORY:-$DOCKER_PROJECT/$IMAGE_NAME} # eg: bitnami/wordpress
 CHART_IMAGE_TAG=${CHART_IMAGE_TAG:-$ROLLING_IMAGE_TAG} # eg: 4.7.6
 CHART_IMAGE=${CHART_IMAGE:-$CHART_IMAGE_REPOSITORY:$CHART_IMAGE_TAG} # eg: bitnami/wordpress:4.7.6
@@ -89,6 +89,22 @@ vercmp() {
       echo "1"
     fi
   fi
+}
+
+readonly __default_platform_regex='^([0-9].*?)-(r[0-9]+)$' # tags for the default platform images, e.g. 1.14.0-r2
+readonly __non_default_platform_regex='^([0-9].*?)-(r[0-9]+)-(.*)$' # tags for the non default platform images, e.g. 1.14.0-r2-ol-7
+
+is_default_platform() {
+    [[ "$1" =~ ${__default_platform_regex} ]]
+}
+
+get_os_platform() {
+    if [[ "$1" =~ ${__non_default_platform_regex} ]]; then
+        echo "${BASH_REMATCH[3]}"
+    else
+        error "Tag $1 does not match regular expression ${__non_default_platform_regex}"
+        return 1
+    fi
 }
 
 install_google_cloud_sdk() {

--- a/circle/functions
+++ b/circle/functions
@@ -91,8 +91,8 @@ vercmp() {
   fi
 }
 
-readonly __default_platform_regex='^([0-9].*?)-(r[0-9]+)$' # tags for the default platform images, e.g. 1.14.0-r2
-readonly __non_default_platform_regex='^([0-9].*?)-(r[0-9]+)-(.*)$' # tags for the non default platform images, e.g. 1.14.0-r2-ol-7
+readonly __default_platform_regex='^(.*?)-(r[0-9]+)$' # tags for the default platform images, e.g. 1.14.0-r2
+readonly __non_default_platform_regex='^(.*?)-(r[0-9]+)-(.*)$' # tags for the non default platform images, e.g. 1.14.0-r2-ol-7
 
 is_default_platform() {
     [[ "$1" =~ ${__default_platform_regex} ]]


### PR DESCRIPTION
 * This reverts commit b42957173a717df5ad50690f88ec5f39d0ef021b (#90).
 * Relax tags regexes to allow minideb-extras tags (e.g. jessie-r43)