### PR TITLE
Add and improve support for multiple variants and distros respectively

### DIFF
--- a/circle/functions
+++ b/circle/functions
@@ -20,6 +20,7 @@ DOCKER_SERVER_VERSION=$(docker version --format '{{.Server.Version}}')
 DOCKER_CLIENT_VERSION=$(docker version --format '{{.Client.Version}}')
 
 DOCKERFILE=${DOCKERFILE:-Dockerfile}
+# Not to be confused with VARIANTS_LIST, which are different images of the same application but different modules
 SUPPORTED_VARIANTS="dev prod onbuild buildpack php"
 
 DOCKER_PROJECT=${DOCKER_PROJECT:-}
@@ -41,7 +42,7 @@ export GITHUB_TOKEN
 
 IMAGE_NAME=${IMAGE_NAME:-}
 IMAGE_TAG=${CIRCLE_TAG:-}
-ROLLING_IMAGE_TAG=$(echo "${IMAGE_TAG}" | sed -E 's/^(.*?)-r[0-9]+(-.*?)?$/\1\2/')
+ROLLING_IMAGE_TAG="${IMAGE_TAG%-r*}"
 CHART_IMAGE_REPOSITORY=${CHART_IMAGE_REPOSITORY:-$DOCKER_PROJECT/$IMAGE_NAME} # eg: bitnami/wordpress
 CHART_IMAGE_TAG=${CHART_IMAGE_TAG:-$ROLLING_IMAGE_TAG} # eg: 4.7.6
 CHART_IMAGE=${CHART_IMAGE:-$CHART_IMAGE_REPOSITORY:$CHART_IMAGE_TAG} # eg: bitnami/wordpress:4.7.6
@@ -73,7 +74,7 @@ warn() {
 }
 
 error() {
-  log "ERROR ==> ${@}"
+  2>&1 log "ERROR ==> ${@}"
 }
 
 # 0 if equal
@@ -94,17 +95,119 @@ vercmp() {
 readonly __default_platform_regex='^(.*?)-(r[0-9]+)$' # tags for the default platform images, e.g. 1.14.0-r2
 readonly __non_default_platform_regex='^(.*?)-(r[0-9]+)-(.*)$' # tags for the non default platform images, e.g. 1.14.0-r2-ol-7
 
-is_default_platform() {
-    [[ "$1" =~ ${__default_platform_regex} ]]
+DEFAULT_DISTRO="debian-8"
+_calculate_non_default_platforms() {
+  local -a variants
+  local -a distros
+
+  IFS=',' read -ra variants <<< "${VARIANTS_LIST:-}," # iterate at least once
+  IFS=',' read -ra distros <<< "${DISTRIBUTIONS_LIST}"
+
+  local -a combinations
+  local suffix
+  for variant in "${variants[@]}"; do
+    for distro in "${distros[@]}"; do
+      suffix=
+      if [[ ${distro} != ${DEFAULT_DISTRO} ]]; then
+        suffix+="-${distro}"
+      fi
+      if [[ ${variant} != "" ]]; then
+        suffix+="-${variant}"
+      fi
+
+      if [ -n "${suffix}" ]; then
+        combinations+=(${suffix})
+      fi
+    done
+  done
+
+  echo ${combinations[@]}
 }
 
-get_os_platform() {
-    if [[ "$1" =~ ${__non_default_platform_regex} ]]; then
-        echo "${BASH_REMATCH[3]}"
-    else
-        error "Tag $1 does not match regular expression ${__non_default_platform_regex}"
-        return 1
+is_default_image() {
+  local image_tag=$1
+  local distro=$1
+  if [ -z ${VARIANTS_LIST+x} ]; then
+    if ! is_default_distro ${distro}; then
+      return 1
     fi
+  else
+    for p in "$(_calculate_non_default_platforms)"; do
+      if [[ $1 == *${p}-r* ]]; then
+        return 1
+      fi
+    done
+  fi
+
+  return 0
+}
+
+is_default_distro() {
+  [[ $1 == ${DEFAULT_DISTRO} ]]
+}
+
+get_distro() {
+  local -a distros
+  IFS=',' read -ra distros <<< "${DISTRIBUTIONS_LIST}"
+
+  for distro in "${distros[@]}"; do
+    if ! is_default_distro "$distro" && [[ $1 == *${distro}-r* ]]; then
+      echo "${distro}"
+      return 0
+    fi
+  done
+
+  echo "${DEFAULT_DISTRO}"
+  return 0
+}
+
+get_variant() {
+  local image_tag=$1
+  local distro=$2
+  local -a variants
+  IFS=',' read -ra variants <<< "${VARIANTS_LIST:-}"
+
+  for variant in "${variants[@]}"; do
+    if is_default_distro ${distro} ; then
+      if [[ ${image_tag} == *${variant}-r* ]]; then
+        echo "${variant}"
+        return 0
+      fi
+    else
+      if [[ ${image_tag} == *${variant}-${distro}-r* ]]; then
+        echo "${variant}"
+        return 0
+      fi
+    fi
+  done
+
+  echo ""
+  return 0
+}
+
+# this filters the branches from the release series, which may include combinations of ${branch}-${variant}
+get_target_branch() {
+  local -a all_release_series=$1
+  local image_tag=$2
+
+  local -a result
+
+  for rs in "${all_release_series[@]}"; do
+    # Release series with dashes mean it's a variant
+    if [[ $rs != *-* && $image_tag == $rs* ]]; then
+      result+=($rs)
+    fi
+  done
+
+  if [[ ${#result[@]} > 1 ]]; then
+    error "Found several possible release series that matches ${image_tag}: ${result[*]}."
+    error "Please review the definition of possible release series"
+    exit 1
+  elif [[ ${#result[@]} == 0 ]]; then
+    error "Cannot find branch for ${image_tag} in release series: ${all_release_series[*]}"
+    exit 1
+  fi
+  echo "${result[0]}"
 }
 
 install_google_cloud_sdk() {
@@ -358,7 +461,7 @@ docker_build() {
       fi
 
       info "Building '$IMAGE_BUILD_TAG-$VARIANT' from '$IMAGE_BUILD_DIR/$VARIANT/'..."
-      if grep -q "^FROM " $IMAGE_BUILD_DIR/$VARIANT/Dockerfile; then\
+      if grep -q "^FROM " $IMAGE_BUILD_DIR/$VARIANT/Dockerfile; then
         docker build $DOCKER_BUILD_CACHE_FROM_ARGS --rm=false -t $IMAGE_BUILD_TAG-$VARIANT $IMAGE_BUILD_DIR/$VARIANT/ || return 1
       else
         echo -e "FROM $IMAGE_BUILD_TAG\n$(cat $IMAGE_BUILD_DIR/$VARIANT/Dockerfile)" | docker build $DOCKER_BUILD_CACHE_FROM_ARGS -t $IMAGE_BUILD_TAG-$VARIANT - || return 1


### PR DESCRIPTION
We will be adding new release series (in the form of top-level new directories for each repository) that may be variants of the same application branch.
This PR refactors the support for multiple distributions and allows building new variants of the same branch.

For it to work needs the new `VARIANTS_LIST` and `DISTRIBUTIONS_LIST` that we will be adding to the `circle.yml` files.

Tested locally against:
 - Nginx image with the regular Debian image.
 - Nginx image with a Debian variant image .
 - Nginx image with an `ol-7` image.
 - Nginx image with an `ol-7` variant image.
 - `minideb-extras` and `oraclelinux-extras`.
