### PR TITLE
Add support for multiple distros and variants for docker-development-image.sh and docker-pull-cache.sh

### DIFF
--- a/circle/docker-image-test.sh
+++ b/circle/docker-image-test.sh
@@ -31,18 +31,20 @@ fi
 if [[ -z $RELEASE_SERIES_LIST ]]; then
   docker_build $DOCKER_PROJECT/$IMAGE_NAME . || exit 1
 else
-  IFS=',' read -ra DISTRIBUTIONS_ARRAY <<< "${DISTRIBUTIONS_LIST:-debian-8}"
-  IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "$RELEASE_SERIES_LIST"
+  IFS=',' read -ra DISTRIBUTIONS_ARRAY <<< "${DISTRIBUTIONS_LIST:-${DEFAULT_DISTRO}}"
+  IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "${RELEASE_SERIES_LIST}"
   for distro in "${DISTRIBUTIONS_ARRAY[@]}"; do
     if [[ "${distro}" == "rhel-"* ]]; then
         echo "${distro} images cannot be built, skipping..."
         continue
     fi
+
     for rs in "${RELEASE_SERIES_ARRAY[@]}"; do
       rs_dir="${rs}"
       if ! is_default_distro "${distro}"; then
         rs_dir+=/${distro}
       fi
+
       must_exist=0
       branch=${rs}
       if [[ $rs != *-* ]]; then

--- a/circle/docker-pull-cache.sh
+++ b/circle/docker-pull-cache.sh
@@ -19,8 +19,15 @@ source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 
 if [[ -n $RELEASE_SERIES_LIST ]]; then
   IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "$RELEASE_SERIES_LIST"
-  for RS in "${RELEASE_SERIES_ARRAY[@]}"; do
-    docker_pull $DOCKER_PROJECT/$IMAGE_NAME:$RS-$CIRCLE_BRANCH || true
+  IFS=',' read -ra DISTRIBUTIONS_ARRAY <<< "${DISTRIBUTIONS_LIST:-${DEFAULT_DISTRO}}"
+  for distro in "${DISTRIBUTIONS_ARRAY[@]}"; do
+    for rs in "${RELEASE_SERIES_ARRAY[@]}"; do
+      tag=${rs}-${CIRCLE_BRANCH}
+      if ! is_default_distro "${distro}"; then
+          tag="${rs}-${distro}-${CIRCLE_BRANCH}"
+      fi
+      docker_pull $DOCKER_PROJECT/$IMAGE_NAME:${tag} || true
+    done
   done
 else
   docker_pull $DOCKER_PROJECT/$IMAGE_NAME:$CIRCLE_BRANCH || true


### PR DESCRIPTION
Following up on #93 and #95, these scripts need modifications too.