### PR TITLE
Avoid updating charts for non-default images

### DIFF
--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -126,7 +126,7 @@ if [[ -n $IBM_PROJECT && -n $IBM_API_KEY ]]; then
   done
 fi
 
-if [[ -n $CHART_REPO && -n $CHART_NAME && -n $DOCKER_PROJECT && -n $DOCKER_PASS ]]; then
+if [[ -n $CHART_REPO && -n $CHART_NAME && -n $DOCKER_PROJECT && -n $DOCKER_PASS && "${IS_DEFAULT_IMAGE}" == 1 ]]; then
   # perform chart updates only for the specified LATEST_STABLE release
   if [[ -n $LATEST_STABLE && "$IMAGE_TAG" == "$LATEST_STABLE"* ]] || [[ -z $LATEST_STABLE ]]; then
     # Update main chart repository


### PR DESCRIPTION
We detected that OracleLinux releases were triggering updates in the Helm charts repo https://github.com/kubernetes/charts/pull/5791/files#r191301432, but this should happen only for Debian non-variant images.