### PR TITLE
adjust tags to work with the new default debian distribution

### DIFF
--- a/circle/docker-development-image.sh
+++ b/circle/docker-development-image.sh
@@ -36,15 +36,7 @@ if [[ -n $DOCKER_PASS ]]; then
         push_tag="${rs}-${IMAGE_TAG}"
         cache_tag="${rs}"
 
-        must_exist=0
-        if [[ $rs != *-* ]]; then
-          # Release series without variants should be available for all the distros supported
-          must_exist=1
-        fi
-
-        if [[ "${must_exist}" == 1 || -f "${rs_dir}/Dockerfile" ]]; then
-          docker_build_and_push "${DOCKER_PROJECT}/${IMAGE_NAME}:${push_tag}" "${rs_dir}" "${DOCKER_PROJECT}/${IMAGE_NAME}:${cache_tag}" || exit 1
-        fi
+        docker_build_and_push "${DOCKER_PROJECT}/${IMAGE_NAME}:${push_tag}" "${rs_dir}" "${DOCKER_PROJECT}/${IMAGE_NAME}:${cache_tag}" || exit 1
       done
     else
       for distro in "${DISTRIBUTIONS_ARRAY[@]}"; do

--- a/circle/docker-development-image.sh
+++ b/circle/docker-development-image.sh
@@ -27,23 +27,14 @@ if [[ -n $DOCKER_PASS ]]; then
   if [[ -z $RELEASE_SERIES_LIST ]]; then
     docker_build_and_push $DOCKER_PROJECT/$IMAGE_NAME:$IMAGE_TAG . $DOCKER_PROJECT/$IMAGE_NAME:latest || exit 1
   else
-    IFS=',' read -ra DISTRIBUTIONS_ARRAY <<< "${DISTRIBUTIONS_LIST:-${DEFAULT_DISTRO}}"
+    IFS=',' read -ra DISTRIBUTIONS_ARRAY <<< "${DISTRIBUTIONS_LIST}"
     IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "${RELEASE_SERIES_LIST}"
-    for distro in "${DISTRIBUTIONS_ARRAY[@]}"; do
-      if [[ "${distro}" == "rhel-"* ]]; then
-        echo "${distro} images cannot be built, skipping..."
-        continue
-      fi
 
+    if is_base_image "${IMAGE_NAME}"; then
       for rs in "${RELEASE_SERIES_ARRAY[@]}"; do
         rs_dir="${rs}"
         push_tag="${rs}-${IMAGE_TAG}"
         cache_tag="${rs}"
-        if ! is_default_distro "${distro}"; then
-          rs_dir+=/${distro}
-          push_tag="${rs}-${distro}-${IMAGE_TAG}"
-          cache_tag="${rs}-${distro}"
-        fi
 
         must_exist=0
         if [[ $rs != *-* ]]; then
@@ -55,7 +46,35 @@ if [[ -n $DOCKER_PASS ]]; then
           docker_build_and_push "${DOCKER_PROJECT}/${IMAGE_NAME}:${push_tag}" "${rs_dir}" "${DOCKER_PROJECT}/${IMAGE_NAME}:${cache_tag}" || exit 1
         fi
       done
-    done
+    else
+      for distro in "${DISTRIBUTIONS_ARRAY[@]}"; do
+        if [[ "${distro}" == "rhel-"* ]]; then
+          echo "${distro} images cannot be built, skipping..."
+          continue
+        fi
+
+        for rs in "${RELEASE_SERIES_ARRAY[@]}"; do
+          rs_dir="${rs}"
+          push_tag="${rs}-${distro}-${IMAGE_TAG}"
+          cache_tag="${rs}-${distro}"
+
+          # TODO(jdrios) remove the conditional once debian-8 is fully deprecated
+          if [[ "${distro}" != "debian-8" ]]; then
+            rs_dir+=/${distro}
+          fi
+
+          must_exist=0
+          if [[ $rs != *-* ]]; then
+            # Release series without variants should be available for all the distros supported
+            must_exist=1
+          fi
+
+          if [[ "${must_exist}" == 1 || -f "${rs_dir}/Dockerfile" ]]; then
+            docker_build_and_push "${DOCKER_PROJECT}/${IMAGE_NAME}:${push_tag}" "${rs_dir}" "${DOCKER_PROJECT}/${IMAGE_NAME}:${cache_tag}" || exit 1
+          fi
+        done
+      done
+    fi
   fi
   dockerhub_update_description || exit 1
 fi

--- a/circle/docker-image-test.sh
+++ b/circle/docker-image-test.sh
@@ -31,7 +31,7 @@ fi
 if [[ -z $RELEASE_SERIES_LIST ]]; then
   docker_build $DOCKER_PROJECT/$IMAGE_NAME . || exit 1
 else
-  IFS=',' read -ra DISTRIBUTIONS_ARRAY <<< "${DISTRIBUTIONS_LIST:-${DEFAULT_DISTRO}}"
+  IFS=',' read -ra DISTRIBUTIONS_ARRAY <<< "${DISTRIBUTIONS_LIST}"
   IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "${RELEASE_SERIES_LIST}"
   for distro in "${DISTRIBUTIONS_ARRAY[@]}"; do
     if [[ "${distro}" == "rhel-"* ]]; then
@@ -41,7 +41,9 @@ else
 
     for rs in "${RELEASE_SERIES_ARRAY[@]}"; do
       rs_dir="${rs}"
-      if ! is_default_distro "${distro}"; then
+
+      # TODO(jdrios) remove the conditional once debian-8 is fully deprecated
+      if "${distro}" != "debian-8"; then
         rs_dir+=/${distro}
       fi
 

--- a/circle/docker-pull-cache.sh
+++ b/circle/docker-pull-cache.sh
@@ -18,17 +18,24 @@ CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent
 source <(curl -sSL $CIRCLE_CI_FUNCTIONS_URL)
 
 if [[ -n $RELEASE_SERIES_LIST ]]; then
-  IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "$RELEASE_SERIES_LIST"
-  IFS=',' read -ra DISTRIBUTIONS_ARRAY <<< "${DISTRIBUTIONS_LIST:-${DEFAULT_DISTRO}}"
+  IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "${RELEASE_SERIES_LIST}"
+  IFS=',' read -ra DISTRIBUTIONS_ARRAY <<< "${DISTRIBUTIONS_LIST}"
   for distro in "${DISTRIBUTIONS_ARRAY[@]}"; do
     for rs in "${RELEASE_SERIES_ARRAY[@]}"; do
-      tag=${rs}-${CIRCLE_BRANCH}
-      if ! is_default_distro "${distro}"; then
-          tag="${rs}-${distro}-${CIRCLE_BRANCH}"
-      fi
+      legacy_tag="${rs}-${CIRCLE_BRANCH}"
+      tag="${rs}-${distro}-${CIRCLE_BRANCH}"
+
       docker_pull $DOCKER_PROJECT/$IMAGE_NAME:${tag} || true
+      # TODO(jdrios) remove once debian-8 is fully deprecated
+      if [[ "${DISTRO}" == "debian-8" ]]; then
+        docker_pull $DOCKER_PROJECT/$IMAGE_NAME:${legacy_tag} || true
+      fi
     done
   done
 else
-  docker_pull $DOCKER_PROJECT/$IMAGE_NAME:$CIRCLE_BRANCH || true
+  IFS=',' read -ra DISTRIBUTIONS_ARRAY <<< "${DISTRIBUTIONS_LIST}"
+  for distro in "${DISTRIBUTIONS_ARRAY[@]}"; do
+    tag="${distro}-${CIRCLE_BRANCH}"
+    docker_pull $DOCKER_PROJECT/$IMAGE_NAME:${tag} || true
+  done
 fi

--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -49,16 +49,14 @@ if [ -n "${VARIANT}" ]; then
   RELEASE_SERIES+="-${VARIANT}"
 fi
 
-CACHE_TAG=${RELEASE_SERIES}
-if [ "${IS_DEFAULT_DISTRO}" == 0 ] ; then
-  CACHE_TAG+="-${DISTRO}"
-fi
+CACHE_TAG=${RELEASE_SERIES}-${DISTRO}
 
 # This case is specific for debian-8 now
-# TODO(jdrios) remove once it is fully deprecated
+# TODO(jdrios) fix once it is fully deprecated
+LATEST_STABLE_DIR=$LATEST_STABLE
 if [[ "${DISTRO}" != "debian-8" ]]; then
   RELEASE_SERIES+="/${DISTRO}"
-  LATEST_STABLE+="/${DISTRO}"
+  LATEST_STABLE_DIR+="/${DISTRO}"
 fi
 
 # Example of tags to update:
@@ -66,8 +64,8 @@ fi
 #  - is not default distro: 1.2-distro 1.2.3-distro 1.2.3-distro-r1
 TAGS_TO_UPDATE+=($CACHE_TAG $IMAGE_TAG $ROLLING_IMAGE_TAG)
 if [[ "${IS_DEFAULT_DISTRO}" == 1 ]]; then
-  TAGS_TO_UPDATE+=(${CACHE_TAG}-${DISTRO} ${IMAGE_TAG//-$DISTRO/} ${ROLLING_IMAGE_TAG//-$DISTRO/})
-  if [[ $RELEASE_SERIES == $LATEST_STABLE && $LATEST_TAG_SOURCE == "LATEST_STABLE" ]]; then
+  TAGS_TO_UPDATE+=(${CACHE_TAG//$DISTRO/} ${IMAGE_TAG//-$DISTRO/} ${ROLLING_IMAGE_TAG//-$DISTRO/})
+  if [[ $RELEASE_SERIES == $LATEST_STABLE_DIR && $LATEST_TAG_SOURCE == "LATEST_STABLE" ]]; then
     TAGS_TO_UPDATE+=('latest')
   fi
 fi

--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -64,7 +64,7 @@ fi
 #  - is not default distro: 1.2-distro 1.2.3-distro 1.2.3-distro-r1
 TAGS_TO_UPDATE+=($CACHE_TAG $IMAGE_TAG $ROLLING_IMAGE_TAG)
 if [[ "${IS_DEFAULT_DISTRO}" == 1 ]]; then
-  TAGS_TO_UPDATE+=(${CACHE_TAG//$DISTRO/} ${IMAGE_TAG//-$DISTRO/} ${ROLLING_IMAGE_TAG//-$DISTRO/})
+  TAGS_TO_UPDATE+=(${CACHE_TAG//-$DISTRO/} ${IMAGE_TAG//-$DISTRO/} ${ROLLING_IMAGE_TAG//-$DISTRO/})
   if [[ $RELEASE_SERIES == $LATEST_STABLE_DIR && $LATEST_TAG_SOURCE == "LATEST_STABLE" ]]; then
     TAGS_TO_UPDATE+=('latest')
   fi

--- a/circle/functions
+++ b/circle/functions
@@ -92,7 +92,8 @@ vercmp() {
   fi
 }
 
-DEFAULT_DISTRO="debian-8"
+DEPRECATED_DEFAULT_DISTRO="debian-8"
+DEFAULT_DISTRO="debian-9"
 
 is_default_image() {
   local distro=$1
@@ -105,8 +106,22 @@ is_default_image() {
   return 0
 }
 
+get_default_distro() {
+  if is_default_distro_transition; then
+    echo "${DEFAULT_DISTRO}"
+    return 0
+  fi
+
+  echo "${DEPRECATED_DEFAULT_DISTRO}"
+  return 0
+}
+
 is_default_distro() {
-  [[ $1 == ${DEFAULT_DISTRO} ]]
+  [[ $1 == "$(get_default_distro)" ]]
+}
+
+is_default_distro_transition() {
+  [[ $DISTRIBUTIONS_LIST == *${DEPRECATED_DEFAULT_DISTRO}* ]] && [[ $DISTRIBUTIONS_LIST == *${DEFAULT_DISTRO}* ]]
 }
 
 get_distro() {
@@ -120,8 +135,7 @@ get_distro() {
     fi
   done
 
-  echo "${DEFAULT_DISTRO}"
-  return 0
+  get_default_distro
 }
 
 get_variant() {

--- a/circle/functions
+++ b/circle/functions
@@ -129,7 +129,10 @@ get_distro() {
     fi
   done
 
-  get_default_distro
+  error "Unable to identify target distribution from the current environment:"
+  error " Distributions list: ${DISTRIBUTIONS_LIST}"
+  error " Default distro:     $(get_default_distro)"
+  exit 1
 }
 
 get_variant() {
@@ -183,9 +186,7 @@ get_target_branch() {
 }
 
 is_base_image() {
-  local image_name=$1
-
-  [[ "${image_name}" == "minideb-extras" ]] || [[ "${image_name}" == "oraclelinux-extras" ]]
+  [[ "${IS_BASE_IMAGE}" == "1" ]]
 }
 
 install_google_cloud_sdk() {

--- a/circle/functions
+++ b/circle/functions
@@ -184,6 +184,12 @@ get_target_branch() {
   echo "${result[0]}"
 }
 
+is_base_image() {
+  local image_name=$1
+
+  [[ "${image_name}" == "minideb-extras" ]] || [[ "${image_name}" == "oraclelinux-extras" ]]
+}
+
 install_google_cloud_sdk() {
   if ! which gcloud >/dev/null ; then
     if ! which python >/dev/null; then

--- a/circle/functions
+++ b/circle/functions
@@ -107,7 +107,7 @@ is_default_image() {
 }
 
 get_default_distro() {
-  if is_default_distro_transition; then
+  if [[ $DISTRIBUTIONS_LIST == *${DEFAULT_DISTRO}* ]]; then
     echo "${DEFAULT_DISTRO}"
     return 0
   fi
@@ -118,10 +118,6 @@ get_default_distro() {
 
 is_default_distro() {
   [[ $1 == "$(get_default_distro)" ]]
-}
-
-is_default_distro_transition() {
-  [[ $DISTRIBUTIONS_LIST == *${DEPRECATED_DEFAULT_DISTRO}* ]] && [[ $DISTRIBUTIONS_LIST == *${DEFAULT_DISTRO}* ]]
 }
 
 get_distro() {

--- a/circle/functions
+++ b/circle/functions
@@ -109,11 +109,9 @@ is_default_image() {
 get_default_distro() {
   if [[ $DISTRIBUTIONS_LIST == *${DEFAULT_DISTRO}* ]]; then
     echo "${DEFAULT_DISTRO}"
-    return 0
+  else
+    echo "${DEPRECATED_DEFAULT_DISTRO}"
   fi
-
-  echo "${DEPRECATED_DEFAULT_DISTRO}"
-  return 0
 }
 
 is_default_distro() {


### PR DESCRIPTION
In order to support debian-9, the images tags should track this new distribution if it is supported. Otherwise, debian-8 should be considered the default distribution during the transition. 

Example supporting both debian-9 and debian-8 during the transition:

```
$ export DISTRIBUTIONS_LIST="debian-8,ol-7,rhel-7,debian-9"

$ CIRCLE_TAG=7.1.36-debian-8-r12 docker-release-image.sh
tags:            7.1-debian-8 7.1.36-debian-8-r12 7.1.36-debian-8
release series:  7.1

$ CIRCLE_TAG=7.1.36-debian-9-r12 docker-release-image.sh
tags:            7.1 7.1.36-debian-9-r12 7.1.36-debian-9 7.1-debian-9 7.1.36-r12 7.1.36 latest
release series:  7.1/debian-9
```

Example supporting only debian-8:

```
$ export DISTRIBUTIONS_LIST="debian-8,ol-7,rhel-7"

$ CIRCLE_TAG=7.1.36-debian-8-r12 docker-release-image.sh
tags:            7.1 7.1-debian-8-r12 7.1.36-debian-8 7.1.36-debian-8 7.1.36-r12 7.1.36 latest
release series:  7.1
```