### PR TITLE
workaround for debian9 transition

### DIFF
--- a/circle/docker-image-test.sh
+++ b/circle/docker-image-test.sh
@@ -85,4 +85,5 @@ if [[ -d .circleci/scripts/post-tests.d/ ]]; then
   done
 fi
 
-docker_save_cache $DOCKER_PROJECT/$IMAGE_NAME
+# TODO(jdrios,alejandro): temporary workaround
+docker_save_cache $DOCKER_PROJECT/$IMAGE_NAME || true


### PR DESCRIPTION
The `docker-image-test.sh` tries to build all the images supported and listed in DISTRIBUTION_LIST, but there is a time window while images are being published when this is not true, and aborts the process of publishing. This becomes an issue when adding support for a new distribution or release series, so we need to make this script ignore errors when running in "release mode".