### PR TITLE
use different condition not to release variants when it is master

### DIFF
--- a/circle/functions
+++ b/circle/functions
@@ -443,7 +443,7 @@ docker_build() {
   # The `prod` containers are built (and published) at the same time that master builds run.
   # Let's skip variant builds for master builds, since `prod` containers use the image tag
   # being published in a parallel build so they will not succeed, ever.
-  if [ "${CIRCLE_BRANCH}" != "master" ]; then
+  if [ -n "${CIRCLE_TAG}" ]; then
     for VARIANT in $SUPPORTED_VARIANTS
     do
       if [[ -f $IMAGE_BUILD_DIR/$VARIANT/Dockerfile ]]; then
@@ -468,13 +468,15 @@ docker_pull() {
   info "Pulling '$IMAGE_BUILD_TAG'..."
   docker pull $IMAGE_BUILD_TAG
 
-  for VARIANT in $SUPPORTED_VARIANTS
-  do
-    if [[ -f $RS/$VARIANT/Dockerfile ]]; then
-      info "Pulling '$IMAGE_BUILD_TAG-$VARIANT'..."
-      docker pull $IMAGE_BUILD_TAG-$VARIANT
-    fi
-  done
+  if [ -n "${CIRCLE_TAG}" ]; then
+    for VARIANT in $SUPPORTED_VARIANTS
+    do
+      if [[ -f $RS/$VARIANT/Dockerfile ]]; then
+        info "Pulling '$IMAGE_BUILD_TAG-$VARIANT'..."
+        docker pull $IMAGE_BUILD_TAG-$VARIANT
+      fi
+    done
+  fi
 }
 
 docker_push() {
@@ -484,13 +486,15 @@ docker_push() {
   info "Pushing '$IMAGE_BUILD_TAG'..."
   docker push $IMAGE_BUILD_TAG
 
-  for VARIANT in $SUPPORTED_VARIANTS
-  do
-    if [[ -f $IMAGE_BUILD_DIR/$VARIANT/Dockerfile ]]; then
-      info "Pushing '$IMAGE_BUILD_TAG-$VARIANT'..."
-      docker push $IMAGE_BUILD_TAG-$VARIANT
-    fi
-  done
+  if [ -n "${CIRCLE_TAG}" ]; then
+    for VARIANT in $SUPPORTED_VARIANTS
+    do
+      if [[ -f $IMAGE_BUILD_DIR/$VARIANT/Dockerfile ]]; then
+        info "Pushing '$IMAGE_BUILD_TAG-$VARIANT'..."
+        docker push $IMAGE_BUILD_TAG-$VARIANT
+      fi
+    done
+  fi
 }
 
 docker_build_and_push() {
@@ -507,13 +511,15 @@ gcloud_docker_push() {
   info "Pushing '$IMAGE_BUILD_TAG'..."
   gcloud docker -- push $IMAGE_BUILD_TAG
 
-  for VARIANT in $SUPPORTED_VARIANTS
-  do
-    if [[ -f $IMAGE_BUILD_DIR/$VARIANT/Dockerfile ]]; then
-      info "Pushing '$IMAGE_BUILD_TAG-$VARIANT'..."
-      gcloud docker -- push $IMAGE_BUILD_TAG-$VARIANT
-    fi
-  done
+  if [ -n "${CIRCLE_TAG}" ]; then
+    for VARIANT in $SUPPORTED_VARIANTS
+    do
+      if [[ -f $IMAGE_BUILD_DIR/$VARIANT/Dockerfile ]]; then
+        info "Pushing '$IMAGE_BUILD_TAG-$VARIANT'..."
+        gcloud docker -- push $IMAGE_BUILD_TAG-$VARIANT
+      fi
+    done
+  fi
 }
 
 gcloud_login() {


### PR DESCRIPTION
The current logic does not cover some cases, such as the `oraclelinux-runtimes` builds. This will trigger the build/push steps too.