### PR TITLE
add support for multiple azure registries

### DIFF
--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -136,12 +136,15 @@ fi
 # We will only publish debian-9 images to Azure Registry
 if [[ "${DISTRO}" == "debian-9" && -n $AZURE_PROJECT && -n $AZURE_PORTAL_PASS && -n $AZURE_PORTAL_USER ]]; then
   az_login || exit 1
-  for TAG in "${TAGS_TO_UPDATE[@]}"; do
-     # Accepted tags on Azure: 1.2 1.2.3 1.2.3-r1 latest
-     # Non accepted Azure: 1.2-distro 1.2.3-distro 1.2.3-distro-r1
-     if [[ "${TAG}" != *${DISTRO}* ]];then
-       docker_build_and_push $AZURE_PROJECT.azurecr.io/$IMAGE_NAME:$TAG $BUILD_DIR ${CACHE_TAG:+$DOCKER_PROJECT/$IMAGE_NAME:$CACHE_TAG} || exit 1
-     fi
+  for ACR in "$AZURE_PORTAL_REGISTRY" "$AZURE_PUBLIC_REGISTRY"; do
+    az acr login --name "$ACR" >/dev/null || exit 1
+    for TAG in "${TAGS_TO_UPDATE[@]}"; do
+       # Accepted tags on Azure: 1.2 1.2.3 1.2.3-r1 latest
+       # Non accepted Azure: 1.2-distro 1.2.3-distro 1.2.3-distro-r1
+       if [[ "${TAG}" != *${DISTRO}* ]];then
+         docker_build_and_push $AZURE_PROJECT.azurecr.io/$IMAGE_NAME:$TAG $BUILD_DIR ${CACHE_TAG:+$DOCKER_PROJECT/$IMAGE_NAME:$CACHE_TAG} || exit 1
+       fi
+    done
   done
 fi
 

--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -142,7 +142,7 @@ if [[ "${DISTRO}" == "debian-9" && -n $AZURE_PROJECT && -n $AZURE_PORTAL_PASS &&
        # Accepted tags on Azure: 1.2 1.2.3 1.2.3-r1 latest
        # Non accepted Azure: 1.2-distro 1.2.3-distro 1.2.3-distro-r1
        if [[ "${TAG}" != *${DISTRO}* ]];then
-         docker_build_and_push $AZURE_PROJECT.azurecr.io/$IMAGE_NAME:$TAG $BUILD_DIR ${CACHE_TAG:+$DOCKER_PROJECT/$IMAGE_NAME:$CACHE_TAG} || exit 1
+         docker_build_and_push "${ACR}.azurecr.io/${IMAGE_NAME}:${TAG}" "${BUILD_DIR}" ${CACHE_TAG:+$DOCKER_PROJECT/$IMAGE_NAME:$CACHE_TAG} || exit 1
        fi
     done
   done

--- a/circle/functions
+++ b/circle/functions
@@ -561,7 +561,6 @@ az_login() {
 
   info "Authenticating with Azure Portal..."
   az login -u "${AZURE_PORTAL_USER}" -p "${AZURE_PORTAL_PASS}" >/dev/null
-  az acr login --name $AZURE_PORTAL_REGISTRY >/dev/null
 }
 
 docker_build_and_gcloud_push() {


### PR DESCRIPTION
As we want to push to two azure container registries, I am splitting the logic that logs in to the acr in two steps.

First of all, we login within the user account. Then, we iterate through the desired registries (added as env vars in the circle ci configuration) logging into them and pushing the images.