### PR TITLE
use project for public registry

### DIFF
--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -138,11 +138,19 @@ if [[ "${DISTRO}" == "debian-9" && -n $AZURE_PROJECT && -n $AZURE_PORTAL_PASS &&
   az_login || exit 1
   for ACR in "$AZURE_PORTAL_REGISTRY" "$AZURE_PUBLIC_REGISTRY"; do
     az acr login --name "$ACR" >/dev/null || exit 1
+
+    # Set registry name
+    registry="${ACR}.azurecr.io"
+    # The public registry uses the `bitnami/app` repository
+    if [[ "${ACR}" == "${AZURE_PUBLIC_REGISTRY}" ]]; then
+      registry+="/bitnami"
+    fi
+
     for TAG in "${TAGS_TO_UPDATE[@]}"; do
        # Accepted tags on Azure: 1.2 1.2.3 1.2.3-r1 latest
        # Non accepted Azure: 1.2-distro 1.2.3-distro 1.2.3-distro-r1
        if [[ "${TAG}" != *${DISTRO}* ]];then
-         docker_build_and_push "${ACR}.azurecr.io/${IMAGE_NAME}:${TAG}" "${BUILD_DIR}" ${CACHE_TAG:+$DOCKER_PROJECT/$IMAGE_NAME:$CACHE_TAG} || exit 1
+         docker_build_and_push "${registry}/${IMAGE_NAME}:${TAG}" "${BUILD_DIR}" ${CACHE_TAG:+$DOCKER_PROJECT/$IMAGE_NAME:$CACHE_TAG} || exit 1
        fi
     done
   done


### PR DESCRIPTION
We need to use different repositories for azure container registries:

 - `bitnami` uses `image`
 - `bitnamiforpublicregistry` uses `bitnami/image`